### PR TITLE
Correct the arg info for several functions

### DIFF
--- a/geospatial.c
+++ b/geospatial.c
@@ -38,7 +38,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(vincenty_args, 0, 0, 2)
 	ZEND_ARG_INFO(0, from_geojson)
 	ZEND_ARG_INFO(0, to_geojson)
-	ZEND_ARG_INFO(0, to_geojson)
+	ZEND_ARG_INFO(0, reference_ellipsoid)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(fraction_along_gc_line_args, 0, 0, 3)


### PR DESCRIPTION
Some of the arg info is out of date following the conversion of all functions to use geojson.
