### PR TITLE
fixed the initial_bearing test

### DIFF
--- a/tests/initial_bearing.phpt
+++ b/tests/initial_bearing.phpt
@@ -15,4 +15,4 @@ $to = array(
 var_dump(initial_bearing($from, $to));
 ?>
 --EXPECT--
-float(148.380993462535)
+float(148.270892801715)


### PR DESCRIPTION
This test was failing, but the expected result was not matching other implementations of this algorithm. This has been updated with the correct result.