### PR TITLE
Relax for aarch64

### DIFF
--- a/tests/OSGB36_to_WGS84.phpt
+++ b/tests/OSGB36_to_WGS84.phpt
@@ -20,7 +20,7 @@ array(4) {
   ["minutes"]=>
   int(14)
   ["seconds"]=>
-  float(11.49337267273%d)
+  float(11.4933726727%d)
   ["direction"]=>
   string(1) "N"
 }


### PR DESCRIPTION
```
========DIFF========
--
       ["minutes"]=>
       int(14)
       ["seconds"]=>
007-   float(11.49337267273%d)
007+   float(11.493372672740634)
       ["direction"]=>
       string(1) "N"
     }
--
========DONE========
FAIL OSGB36 to WGS84 [tests/OSGB36_to_WGS84.phpt] 

```